### PR TITLE
Fix exam alert year and sem storage

### DIFF
--- a/migrations/add_exam_settings_columns.sql
+++ b/migrations/add_exam_settings_columns.sql
@@ -1,0 +1,50 @@
+-- Add missing columns to exam_settings table for storing exam alert data
+-- This migration adds semester, exam_type, refid, and alert_date columns
+
+-- Add semester column
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'semester'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN semester INTEGER;
+    END IF;
+END $$;
+
+-- Add exam_type column
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'exam_type'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN exam_type VARCHAR(50);
+    END IF;
+END $$;
+
+-- Add refid column
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'refid'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN refid VARCHAR(100);
+    END IF;
+END $$;
+
+-- Add alert_date column
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'alert_date'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN alert_date DATE;
+    END IF;
+END $$;

--- a/migrations/update_exam_settings_complete.sql
+++ b/migrations/update_exam_settings_complete.sql
@@ -1,0 +1,113 @@
+-- Complete update to exam_settings table to store all exam alert data
+-- This migration adds all missing columns needed for proper exam alert functionality
+
+-- Add year column (if not already exists from previous migration)
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'year'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN year INTEGER;
+        ALTER TABLE exam_settings ADD CONSTRAINT check_valid_exam_year CHECK (year IN (2, 3));
+    END IF;
+END $$;
+
+-- Add semester column
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'semester'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN semester INTEGER;
+        ALTER TABLE exam_settings ADD CONSTRAINT check_valid_semester CHECK (semester BETWEEN 1 AND 8);
+    END IF;
+END $$;
+
+-- Add exam_type column
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'exam_type'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN exam_type VARCHAR(50);
+        ALTER TABLE exam_settings ADD CONSTRAINT check_valid_exam_type 
+        CHECK (exam_type IN ('IA1', 'IA2', 'IA3', 'MODEL', 'END_SEM', 'Internal Assessment-I', 'Internal Assessment-II', 'Model Exam', 'End Semester'));
+    END IF;
+END $$;
+
+-- Add refid column
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'refid'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN refid VARCHAR(100);
+    END IF;
+END $$;
+
+-- Add alert_date column (for notification/alert scheduling)
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'alert_date'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN alert_date DATE;
+    END IF;
+END $$;
+
+-- Add status column for exam alert status
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'status'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN status VARCHAR(20) DEFAULT 'active';
+        ALTER TABLE exam_settings ADD CONSTRAINT check_valid_status CHECK (status IN ('active', 'closed', 'draft'));
+    END IF;
+END $$;
+
+-- Add title column for exam alert title
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'title'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN title VARCHAR(500);
+    END IF;
+END $$;
+
+-- Add departments column to store which departments the alert applies to
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'exam_settings' 
+        AND column_name = 'departments'
+    ) THEN
+        ALTER TABLE exam_settings ADD COLUMN departments JSONB DEFAULT '[]';
+    END IF;
+END $$;
+
+-- Add indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_exam_settings_year ON exam_settings(year);
+CREATE INDEX IF NOT EXISTS idx_exam_settings_semester ON exam_settings(semester);
+CREATE INDEX IF NOT EXISTS idx_exam_settings_exam_type ON exam_settings(exam_type);
+CREATE INDEX IF NOT EXISTS idx_exam_settings_status ON exam_settings(status);
+CREATE INDEX IF NOT EXISTS idx_exam_settings_created_by ON exam_settings(created_by);
+
+-- Add a composite index for common queries
+CREATE INDEX IF NOT EXISTS idx_exam_settings_year_semester ON exam_settings(year, semester);

--- a/src/components/CreateExamAlert.tsx
+++ b/src/components/CreateExamAlert.tsx
@@ -45,6 +45,7 @@ export const CreateExamAlert: React.FC<CreateExamAlertProps> = ({
       year: formData.year as 2 | 3,
       semester: formData.semester,
       refId: formData.refId,
+      departments: [], // Empty array for now
       status: "active" as const,
       createdBy: user.id,
     };

--- a/src/services/examService.ts
+++ b/src/services/examService.ts
@@ -987,6 +987,8 @@ export const examService = {
     departments: string[];
     status: "active" | "closed";
     createdBy: string;
+    refId?: string;
+    title?: string;
   }): Promise<ExamAlert> {
     const { data, error } = await supabase
       .from("exam_settings")
@@ -994,6 +996,12 @@ export const examService = {
         {
           exam_start_date: alertData.startDate,
           exam_end_date: alertData.endDate,
+          year: alertData.year,
+          semester: alertData.semester,
+          refid: alertData.refId,
+          exam_type: alertData.title?.includes('Internal Assessment') ? 
+            (alertData.title.includes('I') ? 'IA1' : alertData.title.includes('II') ? 'IA2' : 'IA3') :
+            alertData.title?.includes('Model') ? 'MODEL' : 'END_SEM',
           holidays: [],
           created_by: alertData.createdBy,
         },

--- a/src/services/examService.ts
+++ b/src/services/examService.ts
@@ -928,13 +928,13 @@ export const examService = {
 
     return data.map((setting) => ({
       id: setting.id,
-      title: `Exam Settings - ${setting.exam_start_date} to ${setting.exam_end_date}`,
+      title: setting.title || `Exam Settings - ${setting.exam_start_date} to ${setting.exam_end_date}`,
       startDate: setting.exam_start_date,
       endDate: setting.exam_end_date,
-      year: 2, // Use valid year type
-      semester: 3, // Use valid semester type
-      departments: [], // Will need to be derived from other data
-      status: "active",
+      year: setting.year || 2, // Use stored year or default to 2
+      semester: setting.semester || 1, // Use stored semester or default to 1
+      departments: setting.departments ? JSON.parse(setting.departments) : [], // Parse stored departments
+      status: setting.status || "active", // Use stored status or default to active
       createdAt: setting.created_at,
     }));
   },
@@ -948,6 +948,11 @@ export const examService = {
 
     if (updates.startDate) updateData.exam_start_date = updates.startDate;
     if (updates.endDate) updateData.exam_end_date = updates.endDate;
+    if (updates.year) updateData.year = updates.year;
+    if (updates.semester) updateData.semester = updates.semester;
+    if (updates.title) updateData.title = updates.title;
+    if (updates.status) updateData.status = updates.status;
+    if (updates.departments) updateData.departments = JSON.stringify(updates.departments);
 
     const { data, error } = await supabase
       .from("exam_settings")
@@ -967,13 +972,13 @@ export const examService = {
 
     return {
       id: data.id,
-      title: `Exam Settings - ${data.exam_start_date} to ${data.exam_end_date}`,
+      title: data.title || `Exam Settings - ${data.exam_start_date} to ${data.exam_end_date}`,
       startDate: data.exam_start_date,
       endDate: data.exam_end_date,
-      year: 2,
-      semester: 3,
-      departments: [],
-      status: "active",
+      year: data.year || 2,
+      semester: data.semester || 1,
+      departments: data.departments ? JSON.parse(data.departments) : [],
+      status: data.status || "active",
       createdAt: data.created_at,
     };
   },
@@ -999,9 +1004,12 @@ export const examService = {
           year: alertData.year,
           semester: alertData.semester,
           refid: alertData.refId,
+          title: alertData.title,
           exam_type: alertData.title?.includes('Internal Assessment') ? 
             (alertData.title.includes('I') ? 'IA1' : alertData.title.includes('II') ? 'IA2' : 'IA3') :
             alertData.title?.includes('Model') ? 'MODEL' : 'END_SEM',
+          departments: JSON.stringify(alertData.departments),
+          status: alertData.status,
           holidays: [],
           created_by: alertData.createdBy,
         },
@@ -1015,13 +1023,13 @@ export const examService = {
 
     return {
       id: data.id,
-      title: `Exam Settings - ${data.exam_start_date} to ${data.exam_end_date}`,
+      title: data.title || `Exam Settings - ${data.exam_start_date} to ${data.exam_end_date}`,
       startDate: data.exam_start_date,
       endDate: data.exam_end_date,
-      year: alertData.year,
-      semester: alertData.semester,
-      departments: alertData.departments,
-      status: alertData.status,
+      year: data.year || alertData.year,
+      semester: data.semester || alertData.semester,
+      departments: data.departments ? JSON.parse(data.departments) : alertData.departments,
+      status: data.status || alertData.status,
       createdAt: data.created_at,
     };
   },

--- a/supabase-schema-updated.sql
+++ b/supabase-schema-updated.sql
@@ -1,0 +1,99 @@
+-- Updated Complete Database Schema for Exam Management System
+-- This schema includes all the necessary columns for proper exam alert functionality
+
+-- Create departments table
+CREATE TABLE departments (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    code VARCHAR(50) NOT NULL UNIQUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create staff_details table
+CREATE TABLE staff_details (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id UUID NOT NULL UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    phone VARCHAR(50),
+    department_id UUID REFERENCES departments(id) ON DELETE CASCADE,
+    department VARCHAR(255) NOT NULL,
+    role VARCHAR(50) NOT NULL,
+    subject_name VARCHAR(255),
+    subject_code VARCHAR(50),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create subject_detail table
+CREATE TABLE subject_detail (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    subcode VARCHAR(50) NOT NULL UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    department VARCHAR(255) NOT NULL,
+    year INTEGER NOT NULL CHECK (year IN (2, 3)),
+    semester INTEGER NOT NULL DEFAULT 1 CHECK (semester BETWEEN 1 AND 8),
+    is_shared BOOLEAN DEFAULT false,
+    shared_subject_code VARCHAR(50),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create exam_settings table (updated with all necessary columns)
+CREATE TABLE exam_settings (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    exam_start_date DATE NOT NULL,
+    exam_end_date DATE NOT NULL,
+    year INTEGER CHECK (year IN (2, 3)),
+    semester INTEGER CHECK (semester BETWEEN 1 AND 8),
+    exam_type VARCHAR(50) CHECK (exam_type IN ('IA1', 'IA2', 'IA3', 'MODEL', 'END_SEM', 'Internal Assessment-I', 'Internal Assessment-II', 'Model Exam', 'End Semester')),
+    refid VARCHAR(100),
+    alert_date DATE,
+    status VARCHAR(20) DEFAULT 'active' CHECK (status IN ('active', 'closed', 'draft')),
+    title VARCHAR(500),
+    departments JSONB DEFAULT '[]',
+    holidays JSONB DEFAULT '[]',
+    created_by UUID,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create exam_schedules table
+CREATE TABLE exam_schedules (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    subject_id UUID REFERENCES subject_detail(id) ON DELETE CASCADE,
+    exam_date DATE NOT NULL,
+    department_id UUID REFERENCES departments(id) ON DELETE CASCADE,
+    assigned_by UUID NOT NULL REFERENCES staff_details(id) ON DELETE CASCADE,
+    priority_department UUID,
+    exam_type VARCHAR(10) CHECK (exam_type IN ('IA1', 'IA2', 'IA3')),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(subject_id, department_id)
+);
+
+-- Create staff_subjects table for handling multiple subjects per staff member
+CREATE TABLE staff_subjects (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    staff_id UUID REFERENCES staff_details(id) ON DELETE CASCADE,
+    subject_name VARCHAR(255) NOT NULL,
+    subject_code VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(staff_id, subject_code)
+);
+
+-- Add indexes for better query performance
+CREATE INDEX idx_staff_subjects_staff_id ON staff_subjects(staff_id);
+CREATE INDEX idx_exam_schedules_subject_id ON exam_schedules(subject_id);
+CREATE INDEX idx_exam_schedules_department_id ON exam_schedules(department_id);
+CREATE INDEX idx_exam_schedules_assigned_by ON exam_schedules(assigned_by);
+CREATE INDEX idx_subject_detail_semester ON subject_detail(semester);
+CREATE INDEX idx_subject_detail_year_semester ON subject_detail(year, semester);
+CREATE INDEX idx_exam_settings_year ON exam_settings(year);
+CREATE INDEX idx_exam_settings_semester ON exam_settings(semester);
+CREATE INDEX idx_exam_settings_exam_type ON exam_settings(exam_type);
+CREATE INDEX idx_exam_settings_status ON exam_settings(status);
+CREATE INDEX idx_exam_settings_created_by ON exam_settings(created_by);
+CREATE INDEX idx_exam_settings_year_semester ON exam_settings(year, semester);

--- a/update_database.sql
+++ b/update_database.sql
@@ -1,0 +1,45 @@
+-- Complete database update script for exam management system
+-- Run this in your Supabase SQL Editor to update your database structure
+
+-- 1. Add missing columns to exam_settings table
+ALTER TABLE exam_settings ADD COLUMN IF NOT EXISTS year INTEGER;
+ALTER TABLE exam_settings ADD COLUMN IF NOT EXISTS semester INTEGER;
+ALTER TABLE exam_settings ADD COLUMN IF NOT EXISTS exam_type VARCHAR(50);
+ALTER TABLE exam_settings ADD COLUMN IF NOT EXISTS refid VARCHAR(100);
+ALTER TABLE exam_settings ADD COLUMN IF NOT EXISTS alert_date DATE;
+ALTER TABLE exam_settings ADD COLUMN IF NOT EXISTS status VARCHAR(20) DEFAULT 'active';
+ALTER TABLE exam_settings ADD COLUMN IF NOT EXISTS title VARCHAR(500);
+ALTER TABLE exam_settings ADD COLUMN IF NOT EXISTS departments JSONB DEFAULT '[]';
+
+-- 2. Add constraints for data validation
+ALTER TABLE exam_settings ADD CONSTRAINT IF NOT EXISTS check_valid_exam_year CHECK (year IN (2, 3));
+ALTER TABLE exam_settings ADD CONSTRAINT IF NOT EXISTS check_valid_semester CHECK (semester BETWEEN 1 AND 8);
+ALTER TABLE exam_settings ADD CONSTRAINT IF NOT EXISTS check_valid_exam_type 
+CHECK (exam_type IN ('IA1', 'IA2', 'IA3', 'MODEL', 'END_SEM', 'Internal Assessment-I', 'Internal Assessment-II', 'Model Exam', 'End Semester'));
+ALTER TABLE exam_settings ADD CONSTRAINT IF NOT EXISTS check_valid_status CHECK (status IN ('active', 'closed', 'draft'));
+
+-- 3. Add indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_exam_settings_year ON exam_settings(year);
+CREATE INDEX IF NOT EXISTS idx_exam_settings_semester ON exam_settings(semester);
+CREATE INDEX IF NOT EXISTS idx_exam_settings_exam_type ON exam_settings(exam_type);
+CREATE INDEX IF NOT EXISTS idx_exam_settings_status ON exam_settings(status);
+CREATE INDEX IF NOT EXISTS idx_exam_settings_created_by ON exam_settings(created_by);
+CREATE INDEX IF NOT EXISTS idx_exam_settings_year_semester ON exam_settings(year, semester);
+
+-- 4. Update any existing records to have default values
+UPDATE exam_settings SET 
+    year = 2,
+    semester = 1,
+    status = 'active',
+    departments = '[]'
+WHERE year IS NULL OR semester IS NULL OR status IS NULL OR departments IS NULL;
+
+-- 5. Show updated table structure
+SELECT 
+    column_name, 
+    data_type, 
+    is_nullable, 
+    column_default
+FROM information_schema.columns 
+WHERE table_name = 'exam_settings' 
+ORDER BY ordinal_position;


### PR DESCRIPTION
Stores year, semester, refId, and exam type for exam alerts by updating the database schema and service logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cce0258-5533-445c-a0c4-bb008fe2e764">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5cce0258-5533-445c-a0c4-bb008fe2e764">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

